### PR TITLE
Added volume sliders for monitor and stream mix. Retry delay of 1 minute when unable to connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.5.1",
   "description": "A MIDI Mixer plugin for the Wave Link (Wave XLR and Wave:3)",
   "scripts": {
-    "build": "git clean -xdf dist && tsc && midi-mixer pack"
+    "build": "git clean -xdf dist && tsc && midi-mixer pack",
+    "build:watch": "tsc --watch"
   },
   "author": "Anaïs Betts <anais@anaisbetts.org>",
   "license": "MIT",

--- a/src/WaveLinkClient.js
+++ b/src/WaveLinkClient.js
@@ -36,7 +36,7 @@ class WaveLinkClient {
 
     this.websocket = null
 
-    this.output = null
+    this.output = {}
     this.mixers = []
 
     this.isMicrophoneConnected
@@ -203,6 +203,8 @@ class WaveLinkClient {
             mixer.bgColor = bgColor
             mixer.localVolIn = localVolumeIn
             mixer.streamVolIn = streamVolumeIn
+            mixer.isLinked = isLinked
+            mixer.deltaLinked = deltaLinked
 
             mixer.isLocalMuteIn = isLocalInMuted
             mixer.isStreamMuteIn = isStreamInMuted
@@ -218,6 +220,8 @@ class WaveLinkClient {
 
             mixer.iconData = iconData
             mixer.inputType = inputType
+
+            console.log('From change', mixer)
 
             this.mixerVolChanged(mixerId)
           }
@@ -400,7 +404,7 @@ class WaveLinkClient {
     }
 
     // adjust volume based on inputtyp
-    if (slider == "local" && !isLinked) {
+    if (slider == "local") {
       localVol = localVol + vol
     } else if (slider == "stream") {
       streamVol = streamVol + vol
@@ -422,6 +426,22 @@ class WaveLinkClient {
     }
   }
 
+  setOutputVolume(slider, targetVol, muted)
+  {
+    if (slider == "local")
+    {
+      this.output.localVolOut = targetVol
+      this.output.isLocalMuteOut = (undefined !== muted) ? muted : false
+    } else
+    {
+      this.output.streamVolOut = targetVol
+      this.output.isStreamMuteOut = (undefined !== muted) ? muted : false
+
+    }
+
+    return this.setOutputMixer()
+  }
+
   setVolume(mixerTyp, mixerId, slider, targetVol, delay) {
     var timeLeft = delay
     var volumeSteps = 0,
@@ -431,7 +451,7 @@ class WaveLinkClient {
 
     const mixer = this.getMixer(mixerId)
 
-    var isNotBlocked =
+    isNotBlocked =
       mixerTyp == "input"
         ? slider == "local"
           ? mixer.isNotBlockedLocal

--- a/src/WaveLinkClient.js
+++ b/src/WaveLinkClient.js
@@ -199,6 +199,7 @@ class WaveLinkClient {
       ) => {
         this.mixers.forEach((mixer) => {
           if (mixer.mixerId == mixerId) {
+            console.log(mixer);
             mixer.name = mixerName
             mixer.bgColor = bgColor
             mixer.localVolIn = localVolumeIn
@@ -220,8 +221,6 @@ class WaveLinkClient {
 
             mixer.iconData = iconData
             mixer.inputType = inputType
-
-            console.log('From change', mixer)
 
             this.mixerVolChanged(mixerId)
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -194,10 +194,12 @@ async function initialize() {
     {}
   )
 
+  var outputVolume = await client.getMonitoringState();
+  
   // // Create slider for monitor output
   // // Maybe we should try to get the data first?
-  var monitor_mixer_volume = client.output ? client.output.localVolOut : 100
-  var monitor_mixer_muted = client.output ? client.output.isLocalMuteOut : false
+  var monitor_mixer_volume = outputVolume.localVolOut
+  var monitor_mixer_muted = outputVolume.isLocalMuteOut
   const monitor_mixer = new Assignment("wavelink_monitor_mix_volume", {
     name: `Monitor Mix Volume`,
     muted: monitor_mixer_muted,
@@ -223,11 +225,11 @@ async function initialize() {
   })
 
   // Add slider for stream mix output volume
-  var stream_mixer_volume = client.output ? client.output.streamVolOut : 100
-  var stream_mixer_muted = client.output ? client.output.isStreamMuteOut : false
+  var stream_mixer_volume = outputVolume.streamVolOut
+  var stream_mixer_muted = outputVolume.isStreamMuteOut
 
   const stream_mixer = new Assignment("wavelink_stream_mix_volume", {
-    name: `stream Mix Volume`,
+    name: `Stream Mix Volume`,
     muted: stream_mixer_muted,
     volume: volumeWaveLinkToMM(stream_mixer_volume),
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,17 +173,6 @@ async function initialize() {
         })
 
         acc[name] = { mixer, assignment: assign }
-
-        createButton(
-          `${name}_link_sliders`,
-          {
-            name: `Link volume sliders on ${mixer.mixerName}`,
-            active: false
-          },
-          (b) => {
-            
-          }
-        )
       })
 
       mixer.filters.forEach((f) => {

--- a/src/simple-jsonrpc.js
+++ b/src/simple-jsonrpc.js
@@ -215,7 +215,7 @@ export const simple_jsonrpc = function () {
       waitingframe[result.id].resolve(result.result)
       delete waitingframe[result.id]
     } else {
-      console.log("unknown request", result)
+      console.log("unknown request", JSON.stringify(result))
     }
   }
 
@@ -237,7 +237,6 @@ export const simple_jsonrpc = function () {
               request.params
             )
           } else if (isObject(request.params)) {
-            // console.log("handleRemoteRequest.params", dispatcher[request.method]);
             if (dispatcher[request.method].params instanceof Array) {
               var argsValues = []
               dispatcher[request.method].params.forEach(function (arg) {


### PR DESCRIPTION
- Fixed a problem when connecting to wavelink. When wavelink launches after midi mixer, the plugin couldn't connect and would not try again. So you had to reset the plugin every boot, because the sliders wouldn't work.
- Added volume sliders for Monitor Mix and Stream Mix

